### PR TITLE
Use Argparse subcommands for cli

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,133 +10,42 @@
 # Author : Jan Krause-Bilvin
 # First release: 2022-02-02
 
-import os
 import pprint
 import configparser
 import argparse
+import sys
 
 from archive2dna import package
 from archive2dna import dna as dna_module
 
-pp = pprint.PrettyPrinter(depth=6)
+pp = pprint.PrettyPrinter(depth=6, stream=sys.stderr)
 
-# Parse arguments
-usage = """cli.py ACTION FILE_IN FILE_OUT [--id package_id] [--er error_rate] [--config config_section]
-           action : encode | decode | corrupt\n"""
-parser = argparse.ArgumentParser(
-    description="Encode/decode information package to DNA."
-)
-parser.add_argument("action", help="encode | decode | corrupt .")
-parser.add_argument("input_file", help="Input file.")
-parser.add_argument("output_file", help="Output file.")
-parser.add_argument(
-    "--id",
-    dest="package_id",
-    help="Information package ID, used to generate the primer",
-)
-parser.add_argument(
-    "--er",
-    dest="error_rate",
-    type=float,
-    help="Error rate ER in perecentage, used to corrupt the DNA",
-)
-parser.add_argument(
-    "--config", help="Config set to be used, e.g. DEFAULT or BIG (see config.ini)"
-)
-args = parser.parse_args()
 
-# read config
-cfg = configparser.ConfigParser()
-cfg.read("config.ini")
-if args.config == None:
-    cfg_set = "DEFAULT"
-else:
-    cfg_set = args.config
-primer_length = int(cfg[cfg_set]["primer_length"])
-mi = int(cfg[cfg_set]["mi"])
-mo = int(cfg[cfg_set]["mo"])
-index_length = int(cfg[cfg_set]["index_length"])
-index_positions = int(cfg[cfg_set]["index_positions"])
-N = int(cfg[cfg_set]["N"])
-K = int(cfg[cfg_set]["K"])
-target_redundancy = float(cfg[cfg_set]["target_redundancy"])
+def encode(args):
+    binary_data = args.infile.read()
+    container = createContainer(args)
+    container.load_binary(binary_data)
+    container.create_logical_redundancy()
+    container.convert_to_dna()
+    container.compute_segments_sizes()
+    text = container.write_dna()
+    args.outfile.write(text)
+    pp.pprint(container.compute_stats())
 
-# read technical config
-cfg_set = "TECHNICAL"
-if cfg[cfg_set]["auto_zip"] == "False":
-    auto_zip = False
-else:
-    auto_zip = True
-representation_type = cfg[cfg_set]["representation_type"]
-representation_url = cfg[cfg_set]["representation_url"]
-logging_file = cfg[cfg_set]["logging_file"]
-logging_level = cfg[cfg_set]["logging_level"]
 
-if args.package_id == None:
-    primer_length = 0
+def decode(args):
+    dna_data = args.infile.read()
+    container = createContainer(args)
+    container.load_dna(dna_data)
+    container.check_and_correct_logical_redundancy()
+    binary_data = container.write_binary()
+    args.outfile.write(binary_data)
+    pp.pprint(container.compute_stats())
 
-if args.action == "encode":
-    binary = args.input_file
-    dna = args.output_file
-    binary_data = open(binary, "rb").read()
-    c = package.Container(
-        package_id=args.package_id,
-        primer_length=primer_length,
-        mi=mi,
-        mo=mo,
-        index_length=index_length,
-        index_positions=index_positions,
-        N=N,
-        K=K,
-        target_redundancy=target_redundancy,
-        representation_type=representation_type,
-        representation_url=representation_url,
-        logging_file=logging_file,
-        logging_level=logging_level,
-        auto_zip=auto_zip,
-    )
-    c.load_binary(binary_data)
-    c.create_logical_redundancy()
-    c.convert_to_dna()
-    c.compute_segments_sizes()
-    text = c.write_dna()
-    open(dna, "w").write(text)
-    pp.pprint(c.compute_stats())
 
-elif args.action == "decode":
-    binary = args.output_file
-    dna = args.input_file
-    c = package.Container(
-        package_id=args.package_id,
-        primer_length=primer_length,
-        mi=mi,
-        mo=mo,
-        index_length=index_length,
-        index_positions=index_positions,
-        N=N,
-        K=K,
-        target_redundancy=target_redundancy,
-        representation_type=representation_type,
-        representation_url=representation_url,
-        logging_file=logging_file,
-        logging_level=logging_level,
-        auto_zip=auto_zip,
-    )
-    text = open(dna, "r").read()
-    c.load_dna(text)
-    c.check_and_correct_logical_redundancy()
-    binary_data = c.write_binary()
-    open(binary, "wb").write(binary_data)
-    pp.pprint(c.compute_stats())
-
-elif args.action == "corrupt":
-    dna = args.input_file
-    dna_out = args.output_file
-    if args.error_rate is not None:
-        error_rate = args.error_rate / 100
-    else:
-        error_rate = 0.5 / 100
-    text = open(dna, "r").read().split("\n")
+def corrupt(args):
+    error_rate = args.error_rate / 100
+    text = args.infile.read().split("\n")
     corrupted_segments = 0
     number_of_corruptions = 0
     for i in range(len(text)):
@@ -146,9 +55,158 @@ elif args.action == "corrupt":
             corrupted_segments += 1
             number_of_corruptions += corruptions
             text[i] = corrupted
-    open(dna_out, "w").write("\n".join(text))
-    print("Corrupted segments :", corrupted_segments, "/", len(text))
-    print("Total number of corruptions :", number_of_corruptions)
+    args.outfile.write("\n".join(text))
+    print("Corrupted segments :", corrupted_segments, "/", len(text), file=sys.stderr)
+    print("Total number of corruptions :", number_of_corruptions, file=sys.stderr)
 
-else:
-    print(usage)
+
+def createContainer(args):
+    # read config
+    config = configparser.ConfigParser()
+    config.read("config.ini")
+    section = config[args.config]
+    primer_length = int(section["primer_length"])
+    mi = int(section["mi"])
+    mo = int(section["mo"])
+    index_length = int(section["index_length"])
+    index_positions = int(section["index_positions"])
+    N = int(section["N"])
+    K = int(section["K"])
+    target_redundancy = float(section["target_redundancy"])
+
+    # read technical config
+    technical = config["TECHNICAL"]
+    auto_zip = not (technical["auto_zip"] == "False")
+    representation_type = technical["representation_type"]
+    representation_url = technical["representation_url"]
+    logging_file = technical["logging_file"]
+    logging_level = technical["logging_level"]
+
+    if args.package_id == None:
+        primer_length = 0
+
+    return package.Container(
+        package_id=args.package_id,
+        primer_length=primer_length,
+        mi=mi,
+        mo=mo,
+        index_length=index_length,
+        index_positions=index_positions,
+        N=N,
+        K=K,
+        target_redundancy=target_redundancy,
+        representation_type=representation_type,
+        representation_url=representation_url,
+        logging_file=logging_file,
+        logging_level=logging_level,
+        auto_zip=auto_zip,
+    )
+
+
+def ranged_float(min, max):
+    """Returns an argument type function for ArgumentParser checking a float
+    with a range between min and max."""
+
+    def ranged_float_checker(arg):
+        try:
+            f = float(arg)
+        except ValueError:
+            raise argparse.ArgumentTypeError("must be a floating point number")
+        if f < min or f > max:
+            raise argparse.ArgumentTypeError(
+                f"must be in the range [{str(min)} .. {str(max)}]"
+            )
+        return f
+
+    return ranged_float_checker
+
+
+# Main parser.
+parser = argparse.ArgumentParser(
+    description="Encode/decode information package to DNA."
+)
+parser.add_argument(
+    "--config",
+    default="DEFAULT",
+    help="Config set to be used, e.g. DEFAULT or BIG (see config.ini)",
+)
+subparsers = parser.add_subparsers(required=True)
+
+# Encode parser.
+encode_parser = subparsers.add_parser("encode", help="encode binary data into dna")
+encode_parser.set_defaults(func=encode)
+encode_parser.add_argument(
+    "--id",
+    dest="package_id",
+    help="Information package ID, used to generate the primer",
+)
+encode_parser.add_argument(
+    "infile",
+    nargs="?",
+    type=argparse.FileType("rb"),
+    default=sys.stdin.buffer,
+    help="input binary file",
+)
+encode_parser.add_argument(
+    "outfile",
+    nargs="?",
+    type=argparse.FileType("w"),
+    default=sys.stdout,
+    help="output dna formatted file",
+)
+
+# Decode parser.
+decoder_parser = subparsers.add_parser(
+    "decode", help="decode dna back into the original binary representation"
+)
+decoder_parser.set_defaults(func=decode)
+decoder_parser.add_argument(
+    "--id",
+    dest="package_id",
+    help="Information package ID, used to generate the primer",
+)
+decoder_parser.add_argument(
+    "infile",
+    nargs="?",
+    type=argparse.FileType("r"),
+    default=sys.stdin,
+    help="input dna formatted file",
+)
+decoder_parser.add_argument(
+    "outfile",
+    nargs="?",
+    type=argparse.FileType("wb"),
+    default=sys.stdout.buffer,
+    help="output binary file",
+)
+
+# Corrupt parser.
+corrupt_parser = subparsers.add_parser(
+    "corrupt", help="corrupt dna for testing purposes"
+)
+corrupt_parser.set_defaults(func=corrupt)
+corrupt_parser.add_argument(
+    "-e",
+    "--error-rate",
+    default=0.5,
+    dest="error_rate",
+    type=ranged_float(0, 100),
+    help="Error rate ER in percentage, used to corrupt the DNA",
+)
+corrupt_parser.add_argument(
+    "infile",
+    nargs="?",
+    type=argparse.FileType("r"),
+    default=sys.stdin,
+    help="input dna formatted file",
+)
+corrupt_parser.add_argument(
+    "outfile",
+    nargs="?",
+    type=argparse.FileType("w"),
+    default=sys.stdout,
+    help="output corrupted dna formatted file",
+)
+
+args = parser.parse_args()
+args.func(args)


### PR DESCRIPTION
This pull request includes multiple improvements to the CLI, including:

- Implementing the `encode`, `decode` and `corrupt` actions as [argparse sub-commands](https://docs.python.org/3/library/argparse.html#sub-commands). This has multiple benefits:
  
  - It allows moving the different actions logic into distinct functions and having argparse automatically select the correct one. For more information, see the section in the linked documentation starting with:
    
    > One particularly effective way of handling sub-commands is to combine the use of the [add_subparsers()](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_subparsers) method with calls to [set_defaults()](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.set_defaults) so that each subparser knows which Python function it should execute.

  - It allows documenting the sub-commands using the `help` parameter of the sub-parsers and provides automatic `--help` for each of those commands, making the usage output not necessary anymore:

    ```
    python3 cli.py --help
    usage: cli.py [-h] [--config CONFIG] {encode,decode,corrupt} ...

    Encode/decode information package to DNA.

    positional arguments:
      {encode,decode,corrupt}
        encode              encode binary data into dna
        decode              decode dna back into the original binary representation
        corrupt             corrupt dna for testing purposes
    
    optional arguments:
      -h, --help            show this help message and exit
      --config CONFIG       Config set to be used, e.g. DEFAULT or BIG (see config.ini)
    ```

- I explicitly declared defaults for all arguments into the `add_argument` calls, including default values of `sys.stdin` for input files and `sys.stdout` for output files. This follows the common standard of UNIX tools and allows the cli to be piped. To see what the result looks like, here's a one line command to download a GIF online, encode it to DNA, corrupt it, and decode it back to a GIF:

  ```
  wget -O - https://media.giphy.com/media/xWJOxVYbzGVtm/giphy.gif | python3 cli.py encode | python3 cli.py corrupt | python3 cli.py decode > dna.gif
  ```

- Stats and debug output where sent to `stderr` to avoid them being included in the output when sent to `stdout`.